### PR TITLE
feat(bookmarks): use native marks for bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,32 +26,22 @@ Automatically disable stuff for large files
 ```
 
 ## bookmarks
-Bookmark files and lines using quickfix list.
-
-### Default config
-```lua
-{
-    name = 'Bookmarks', -- Name of the quickfix list
-}
-```
+Bookmark files using native marks.
 
 ### Usage
-Best used with `session` plugin with `extra.quickfix = true` to automatically save and load quickfix lists (including bookmarks).
 
 ```lua
 local bookmarks = require('myplugins.bookmarks')
-vim.keymap.set('n', '<leader>jj', bookmarks.toggle_file)
-vim.keymap.set('n', '<leader>jl', bookmarks.toggle_line)
-vim.keymap.set('n', '<leader>jk', bookmarks.load)
-vim.keymap.set('n', '<leader>jx', bookmarks.clear)
-vim.keymap.set('n', ']j', function()
-    bookmarks.load()
-    vim.cmd('silent! cnext')
-end)
-vim.keymap.set('n', '[j', function()
-    bookmarks.load()
-    vim.cmd('silent! cprevious')
-end)
+vim.keymap.set('n', '<leader>mm', bookmarks.select, { desc = 'Bookmarks Select' })
+vim.keymap.set('n', '<leader>mq', bookmarks.quickfix, { desc = 'Bookmarks Quickfix' })
+vim.keymap.set('n', '<leader>md', bookmarks.delete_buffer, { desc = 'Bookmarks Delete Buffer' })
+vim.keymap.set('n', '<leader>mD', bookmarks.delete_all, { desc = 'Bookmarks Delete All' })
+vim.keymap.set('n', "'", function()
+    bookmarks.jump_to_mark(vim.fn.getcharstr())
+end, { desc = 'Bookmarks Jump to Mark' })
+vim.keymap.set('n', 'm', function()
+    bookmarks.toggle_mark(vim.fn.getcharstr())
+end, { desc = 'Bookmarks Toggle Mark' })
 ```
 
 ## bufcomplete


### PR DESCRIPTION
Refactor bookmarks plugin to use native marks instead of quickfix lists. Removes quickfix-based file and line bookmarking, and introduces mark-based navigation and management. Updates keymaps and documentation to reflect new usage. This simplifies bookmark handling and improves performance.